### PR TITLE
WIP: Switch to `fetchFromGithub`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ros-indigo
 ros-kinetic
 ros-lunar
 .coverage
+*.ignore

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -90,6 +90,11 @@ def generate_installers(
             err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))
             bad_installers.append(pkg)
             failed = failed + 1
+        except FileNotFoundError:
+            failed_msg = 'Failed to generate %s FileNotFoundError' % what_generating
+            err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))
+            bad_installers.append(pkg)
+            failed = failed + 1
         except KeyError:
             failed_msg = 'Failed to generate %s' % what_generating
             err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))

--- a/superflore/generate_installers.py
+++ b/superflore/generate_installers.py
@@ -19,6 +19,7 @@ from superflore.utils import get_pkg_version
 from superflore.utils import info
 from superflore.utils import ok
 from superflore.utils import warn
+import tarfile
 
 
 def generate_installers(
@@ -83,6 +84,11 @@ def generate_installers(
                     percent, str(ub), pkg
                 )
             )
+            failed = failed + 1
+        except tarfile.ReadError:
+            failed_msg = 'Failed to generate %s tarfile.ReadError' % what_generating
+            err("{0}%: {1} for package {2}!".format(percent, failed_msg, pkg))
+            bad_installers.append(pkg)
             failed = failed + 1
         except KeyError:
             failed_msg = 'Failed to generate %s' % what_generating

--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -192,7 +192,7 @@ class NixExpression:
               version = "{version}";
                 
               src = let
-                 fetchFromGithub = (builtins.import (builtins.fetchTarball ({{ url = "https://github.com/NixOS/nixpkgs/archive/aa0e8072a57e879073cee969a780e586dbe57997.tar.gz"; }})) ({{}})).fetchFromGitHub;
+                  fetchFromGithub = (builtins.import (builtins.fetchTarball ({{ url = "https://github.com/NixOS/nixpkgs/archive/aa0e8072a57e879073cee969a780e586dbe57997.tar.gz"; }})) ({{}})).fetchFromGitHub;
                 in
                   fetchFromGithub {{
                     owner = "{owner}";

--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -181,7 +181,7 @@ class NixExpression:
             import subprocess
             try:
                 # this sha256 can be different from the tarball sha256 (e.g. self.src_256)
-                sha256 = subprocess.check_output(['nix-prefetch', 'fetchFromGitHub', "--repo", repo, "--owner", owner, "--rev", rev ]).decode('utf-8')[0:-1]
+                sha256 = subprocess.check_output(['nix-prefetch', 'fetchFromGitHub', '--quiet', "--repo", repo, "--owner", owner, "--rev", rev ]).decode('utf-8')[0:-1]
             except Exception as error:
                 print(f'''if you're seeing this warning a lot, please install nix-prefetch then re-run this script''')
                 sha256 = self.src_sha256
@@ -192,7 +192,7 @@ class NixExpression:
               version = "{version}";
                 
               src = let
-                 fetchFromGithub = (builtins.import (builtins.fetchTarball ({{ url = "https://github.com/NixOS/nixpkgs/archive/aa0e8072a57e879073cee969a780e586dbe57997.tar.gz"; }})) ({{}})).fetchFromGitHub
+                 fetchFromGithub = (builtins.import (builtins.fetchTarball ({{ url = "https://github.com/NixOS/nixpkgs/archive/aa0e8072a57e879073cee969a780e586dbe57997.tar.gz"; }})) ({{}})).fetchFromGitHub;
                 in
                   fetchFromGithub {{
                     owner = "{owner}";

--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -141,7 +141,7 @@ class NixExpression:
             # folders[3] == "archive"
             # folders[4:] == the tag + ".tar.gz"
             owner = folders[1]
-            repo_name = folders[2]
+            repo = folders[2]
             
             tag_name_pieces = folders[4:]
             # chop off the .tar.gz part

--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -184,7 +184,7 @@ class NixExpression:
                 sha256 = subprocess.check_output(['nix-prefetch', 'fetchFromGitHub', "--repo", repo, "--owner", owner, "--rev", rev ]).decode('utf-8')[0:-1]
             except Exception as error:
                 print(f'''if you're seeing this warning a lot, please install nix-prefetch then re-run this script''')
-                sha256 = "sha256:0000000000000000000000000000000000000000000000000000"
+                sha256 = self.src_sha256
             
             ret += dedent('''
             buildRosPackage {{

--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -117,6 +117,16 @@ class NixExpression:
     def _to_nix_parameter(dep: str) -> str:
         return dep.split('.')[0]
 
+    @property
+    def url_host(self):
+        # https://github.com/owner/repo/whatever => "github.com"
+        if self.src_url:
+            after_the_https_part = self.src_url.split("//")[1]
+            first_slash_index = after_the_https_part.index("/")
+            if first_slash_index == -1:
+                first_slash_index = len(after_the_https_part)
+            return after_the_https_part[0:first_slash_index]
+    
     def get_text(self, distributor: str, license_name: str) -> str:
         """
         Generate the Nix expression, given the distributor line

--- a/superflore/generators/nix/nix_package.py
+++ b/superflore/generators/nix/nix_package.py
@@ -48,12 +48,15 @@ class NixPackage:
         else:
             info("downloading archive version for package '{}'..."
                  .format(name))
-            retry_on_exception(download_file, src_uri, archive_path,
-                               retry_msg="network error downloading '{}'"
-                               .format(src_uri),
-                               error_msg="failed to download archive for '{}'"
-                               .format(name))
-            downloaded_archive = True
+            try:
+                retry_on_exception(download_file, src_uri, archive_path,
+                                retry_msg="network error downloading '{}'"
+                                .format(src_uri),
+                                error_msg="failed to download archive for '{}'"
+                                .format(name))
+                downloaded_archive = True
+            except Exception as error:
+                pass
 
         if downloaded_archive or archive_path not in sha256_cache:
             sha256_cache[archive_path] = hashlib.sha256(

--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -77,6 +77,8 @@ def main():
         preserve_existing = False
     elif args.only:
         parser.error('Invalid args! --only requires specifying --ros-distro')
+    else:
+        raise Exception(f'''Please add one of the following:\n    --all\n    --ros_distro DISTRO_NAME_HERE''')
     if not selected_targets:
         selected_targets = get_distros_by_status('active') + \
             get_distros_by_status('rolling')

--- a/tests/bootstrap_nix_dryrun.sh
+++ b/tests/bootstrap_nix_dryrun.sh
@@ -41,4 +41,21 @@ fi
 # actual run
 # 
 sudo python3 ./setup.py install
-superflore-gen-nix --dry-run
+
+tar_cache_folder=".temp.ignore/tar_cache/"
+mkdir -p "$tar_cache_folder"
+
+output_folder=".temp.ignore/nix-ros-overlay/"
+
+if ! [ -d "$output_folder" ]
+then
+    cd "$(dirname "$output_folder")"
+    git clone git@github.com:jeff-hykin/nix-ros-overlay.git
+    cd -
+fi
+
+superflore-gen-nix \
+    --dry-run \
+    --all \
+    --output-repository-path "$output_folder" \
+    --tar-archive-dir "$tar_cache_folder"

--- a/tests/bootstrap_nix_dryrun.sh
+++ b/tests/bootstrap_nix_dryrun.sh
@@ -29,11 +29,16 @@ fi
 # 
 # actual setup
 # 
-sudo python3 ./setup.py install
-sudo rosdep init
-rosdep update
+# if superflore-gen-nix doesnt exist
+if [ -z "$(command -v "superflore-gen-nix")" ]
+then
+    sudo python3 ./setup.py install
+    sudo rosdep init
+    rosdep update
+fi
 
 # 
 # actual run
 # 
+sudo python3 ./setup.py install
 superflore-gen-nix --dry-run

--- a/tests/bootstrap_nix_dryrun.sh
+++ b/tests/bootstrap_nix_dryrun.sh
@@ -1,0 +1,39 @@
+# if git doesnt exist
+if [ -z "$(command -v "git")" ]
+then
+    echo "not even sure how you got this code without git, please install git"
+    exit
+fi
+
+# if python3 doesnt exist
+if [ -z "$(command -v "python3")" ]
+then
+    echo "please install python3"
+    exit
+fi
+
+# if nix doesnt exist
+if [ -z "$(command -v "nix")" ]
+then
+    echo "please install nix"
+    exit
+fi
+
+# if nix-prefetch doesnt exist
+if [ -z "$(command -v "nix-prefetch")" ]
+then
+    nix-env -iA nixpkgs.nix-prefetch -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/aa0e8072a57e879073cee969a780e586dbe57997.tar.gz
+fi
+
+
+# 
+# actual setup
+# 
+sudo python3 ./setup.py install
+sudo rosdep init
+rosdep update
+
+# 
+# actual run
+# 
+superflore-gen-nix --dry-run


### PR DESCRIPTION
I put the results of this change as the [other PR](https://github.com/lopsided98/nix-ros-overlay/pull/242)

What will probably block this PR is that, I didn't want to risk/deal with adding `fetchFromGithub` as a function argument (and then figuring out where the function is called), so I just in-place pulled it from a pinned version of nixpkgs.

**(Wanted to get your opinion on that^)**

Other than that, I tested the 
```sh
nix-shell -I \
    nix-ros-overlay=https://github.com/jeff-hykin/nix-ros-overlay/archive/5e2d7097caad7bc5cf43f90fbd3aedd2ca91e5d0.tar.gz \
    --option extra-substituters "https://ros.cachix.org" \
    --option trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ros.cachix.org-1:dSyZxI8geDCJrwgvCOHDoAfOm5sV1wCPjBkKL+38Rvo=" \
    "<nix-ros-overlay/examples/turtlebot3-gazebo.nix>"
```

