### PR TITLE
Escape quote in license string

### DIFF
--- a/superflore/generators/nix/nix_expression.py
+++ b/superflore/generators/nix/nix_expression.py
@@ -31,6 +31,8 @@ import urllib.parse
 
 from superflore.utils import get_license
 
+def _sanitize_nix_string(string: str):
+    return string.replace("\\", "\\\\").replace("${", r"\${").replace('"', r'\"')
 
 class NixLicense:
     """
@@ -72,7 +74,7 @@ class NixLicense:
     @property
     def nix_code(self) -> str:
         if self.custom:
-            return '"{}"'.format(self.name)
+            return '"{}"'.format(_sanitize_nix_string(self.name))
         else:
             return self.name
 

--- a/tests/test_nix.py
+++ b/tests/test_nix.py
@@ -16,7 +16,6 @@ import unittest
 
 from superflore.generators.nix.nix_expression import NixLicense
 
-
 class TestNixLicense(unittest.TestCase):
 
     def test_known_license(self):
@@ -30,3 +29,11 @@ class TestNixLicense(unittest.TestCase):
     def test_public_domain(self):
         l = NixLicense("Public Domain")
         self.assertEqual(l.nix_code, 'publicDomain')
+
+    def test_escape_quote(self): 
+        l = NixLicense(r'license with "quotes" and \backslash" ');
+        self.assertEqual(l.nix_code, r'"license-with-\"quotes\"-and-\\backslash"')
+    
+    def test_escape_quote(self): 
+        l = NixLicense('some license with the "${" sequence');
+        self.assertEqual(l.nix_code, r'"some-license-with-the-\"\${\"-sequence"')


### PR DESCRIPTION
The license string in the generated nix package file was broken when the license name contained quote.

It has been fixed by escaping it as suggested.

closes https://github.com/lopsided98/nix-ros-overlay/issues/356