### PR TITLE
Fix handling of --pr-only

### DIFF
--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -59,7 +59,7 @@ def main():
         if not args.output_repository_path:
             parser.error('Invalid args! no repository specified')
         try:
-            prev_overlay = RepoInstance(args.output_repository_path, False)
+            prev_overlay = NixRosOverlay(args.output_repository_path, False)
             msg, title = load_pr()
             prev_overlay.pull_request(msg, title=title)
             clean_up()

--- a/superflore/generators/nix/run.py
+++ b/superflore/generators/nix/run.py
@@ -59,7 +59,11 @@ def main():
         if not args.output_repository_path:
             parser.error('Invalid args! no repository specified')
         try:
-            prev_overlay = NixRosOverlay(args.output_repository_path, False)
+            prev_overlay = NixRosOverlay(
+                args.output_repository_path,
+                False,
+                from_branch=args.upstream_branch,
+            )
             msg, title = load_pr()
             prev_overlay.pull_request(msg, title=title)
             clean_up()


### PR DESCRIPTION
I'm working on updating nix-ros-overlay update action to not only run superflore, but also update versions and hashes needed for `patchAmentVendorGit`. The plan (and almost working implementation) is that instead of just running `superflore`, the update action will run:

1. `superflore --dry-run ...`
2. other updates
3. `superflore --pr-only`

The 3rd step would generate the same PR as before except that it will also include the commits made by step 2. The changes in this PR make step 3 work as needed.

Without this change, running "superflore-gen-nix --pr-only" fails with this error:
    
    !!!! Failed to file PR!
    !!!! reason: Cmd('/nix/store/cjw8ydwnifad0wdlkhpsyrdm18bcmg63-git-minimal-2.47.2/bin/git') failed due to: exit code(128)
      cmdline: /nix/store/cjw8ydwnifad0wdlkhpsyrdm18bcmg63-git-minimal-2.47.2/bin/git clone -v --branch=master -- https://github.com/./False False
      stderr: 'Cloning into 'False'...
    remote: Not Found
    fatal: repository 'https://github.com/./False/' not found
    '